### PR TITLE
fix null reference exception on cache.clear

### DIFF
--- a/CR API csharp wrapper/Wrapper.cs
+++ b/CR API csharp wrapper/Wrapper.cs
@@ -869,7 +869,10 @@ namespace CRAPI
         /// </summary>
         public void Clear()
         {
-            cache.Clear();
+            //check to make sure cache is not already null before clearing it
+            if (cache != null) { 
+                cache.Clear();
+            }
 
             string[] files = Directory.GetFiles(Path.Combine(Path.GetTempPath()), "*" + tempFileSuffix);
 


### PR DESCRIPTION
This change checks if the "cache" is already empty before clearing it, to avoid a null reference exception. You may want to go further in depth as to why it's null at this point if you don't expect it to be, but this at least gets the API working again for me.